### PR TITLE
EEPROM persistent parameters for F4 boards

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,10 @@
 [submodule "comms/mavlink/v1.0"]
-	path = comms/mavlink/v1.0
-	url = https://github.com/rosflight/mavlink_c_library.git
+        path = comms/mavlink/v1.0
+        url = https://github.com/rosflight/mavlink_c_library.git
 [submodule "boards/breezy/breezystm32"]
-	path = boards/breezy/breezystm32
-	url = https://github.com/rosflight/BreezySTM32.git
+        path = boards/breezy/breezystm32
+        url = https://github.com/rosflight/BreezySTM32.git
 [submodule "boards/airbourne/airbourne"]
-	path = boards/airbourne/airbourne
-	url = https://github.com/rosflight/airbourne_f4.git
+        path = boards/airbourne/airbourne
+        branch = eeprom-persistent-parameters
+        url = https://github.com/rosflight/airbourne_f4.git

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ PARALLEL_JOBS	:= $(shell grep -c ^processor /proc/cpuinfo)
 #################################
 # List of valid boards (update with new boards)
 VALID_F1_BOARDS = NAZE
-VALID_F4_BOARDS = REVO
+VALID_F4_BOARDS = REVO REVO_EEPROM
 
 # Make sure that the supplied board is supported, and if so,
 # set the proper board directory

--- a/boards/airbourne/Makefile
+++ b/boards/airbourne/Makefile
@@ -35,6 +35,14 @@ DEBUG ?= GDB
 SERIAL_DEVICE ?= /dev/ttyACM0
 
 
+#################################
+# Custom board configurations
+#################################
+BOARD_CXX_FLAGS = 
+ifeq ($(BOARD), REVO_EEPROM)
+BOARD_CXX_FLAGS += -DPARAM_EEPROM_PERSISTENT
+endif
+
 
 #################################
 # Working directories
@@ -174,7 +182,7 @@ INCLUDE_DIRS += $(AIRBOURNE_SRC_DIR) \
 MCFLAGS= -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion
 DEFS+=-DSTM32F40_41xxx -D__CORTEX_M4 -D__FPU_PRESENT -DWORDS_STACK_SIZE=200 -DUSE_STDPERIPH_DRIVER -D__FPU_USED -DHSE_VALUE=8000000 -DUSE_USB_OTG_FS
 CFLAGS += $(MCFLAGS) $(OPTIMIZE) $(addprefix -I,$(INCLUDE_DIRS))
-CXXFLAGS += $(MCFLAGS) $(OPTIMIZE) $(addprefix -I,$(INCLUDE_DIRS))
+CXXFLAGS += $(MCFLAGS) $(OPTIMIZE) $(addprefix -I,$(INCLUDE_DIRS)) $(BOARD_CXX_FLAGS)
 LDFLAGS =-T $(LDSCRIPT) $(MCFLAGS) -lm -lc --specs=nano.specs --specs=rdimon.specs $(ARCH_FLAGS)  $(LTO_FLAGS)  $(DEBUG_FLAGS) -static  -Wl,-gc-sections -Wl,-Map=main.map
 
 $(info VPATH = $(VPATH))

--- a/boards/airbourne/airbourne_board.cpp
+++ b/boards/airbourne/airbourne_board.cpp
@@ -415,22 +415,6 @@ bool AirbourneBoard::rc_lost()
   return rc_->lost();
 }
 
-// non-volatile memory
-void AirbourneBoard::memory_init()
-{
-  return flash_.init(&spi3_);
-}
-
-bool AirbourneBoard::memory_read(void *data, size_t len)
-{
-  return flash_.read_config(reinterpret_cast<uint8_t *>(data), len);
-}
-
-bool AirbourneBoard::memory_write(const void *data, size_t len)
-{
-  return flash_.write_config(reinterpret_cast<const uint8_t *>(data), len);
-}
-
 // LED
 void AirbourneBoard::led0_on()
 {
@@ -460,6 +444,34 @@ void AirbourneBoard::led1_off()
 void AirbourneBoard::led1_toggle()
 {
   led2_.toggle();
+}
+
+// non-volatile memory
+void AirbourneBoard::memory_init()
+{
+#ifdef PARAM_EEPROM_PERSISTENT
+  return eeprom_init();
+#else
+  return flash_.init(&spi3_);
+#endif
+}
+
+bool AirbourneBoard::memory_read(void *data, size_t len)
+{
+#ifdef PARAM_EEPROM_PERSISTENT
+  return eeprom_read(data, len);
+#else
+  return flash_.read_config(reinterpret_cast<uint8_t *>(data), len);
+#endif
+}
+
+bool AirbourneBoard::memory_write(const void *data, size_t len)
+{
+#ifdef PARAM_EEPROM_PERSISTENT
+  return eeprom_write(data, len);
+#else
+  return flash_.write_config(reinterpret_cast<const uint8_t *>(data), len);
+#endif
 }
 
 // Backup memory

--- a/boards/airbourne/airbourne_board.h
+++ b/boards/airbourne/airbourne_board.h
@@ -32,7 +32,12 @@
 #ifndef ROSFLIGHT_FIRMWARE_AIRBOURNE_BOARD_H
 #define ROSFLIGHT_FIRMWARE_AIRBOURNE_BOARD_H
 
+#ifdef PARAM_EEPROM_PERSISTENT
+#include "eeprom.h"
+#else
 #include "M25P16.h"
+#endif
+
 #include "analog_digital_converter.h"
 #include "analog_pin.h"
 #include "backup_sram.h"
@@ -86,10 +91,13 @@ private:
   PWM_OUT esc_out_[PWM_NUM_OUTPUTS];
   LED led2_;
   LED led1_;
-  M25P16 flash_;
   AnalogDigitalConverter battery_adc_;
   BatteryMonitor battery_monitor_;
   UBLOX gnss_;
+  
+  #ifndef PARAM_EEPROM_PERSISTENT
+  M25P16 flash_;
+  #endif
 
   enum SerialDevice : uint32_t
   {


### PR DESCRIPTION
This pull request solves rosflight/rosflight#144

- **Makefile infrastructure proposal** for handling minor custom board adaptions
    - Build with eeprom using `make BOARD=REVO_EEPROM` instead of default with `make BOARD=REVO`
    -  The process for adding new boards is simply adding the board name to the `firmware` Makefile  with `VALID_F4_BOARDS = REVO REVO_EEPROM` the rest is handled in the corresponding chip architecture specific `BOARD_DIR` (F4 - airbourne in this case)
    - In airbourne a new segment is included with `custom board configurations` that define preprocessor flags that are added to `BOARD_CXX_FLAGS = ` and in the source code non-compatible libraries and objects are excluded by only instantiating in case of  `#ifndef` and required packages included with `#ifdef PARAM_EEPROM_PERSISTENT`
- **EEPROM persistent parameters** for F4 FCUs without `M25P16` by changing the `airbourne.h` and `airbourne.cpp` 
    - changing the `uint8_t` of the `eeprom` library in the `airbourne_f4` submodule (see rosflight/airbourne_f4#63) and replacing the corresponding board memory access functions from `M25P16` to `eeprom`


----

**Conclusions:**
- Structure: Alternatively the complete board could be copied instead of preprocessor directives. But potentially requires code duplication in case of changes and risks single board copies to become outdated.
- Data types: Chose `uint32_t` but could also be `uint16_t`: future robustness vs optimisation
- Hardware tests: Runtime parameter retrieval successful with local board using `make BOARD=REVO_EEPROM SERIAL_DEVICE=/dev/ttyACM0 flash`, changing parameters with multiple parameters (One of which e.g. `rosservice call /param_set MIXER 2` and `rosservice call /param_write`, power toggling and verifying mixer with `rosservice call /param_get MIXER`)
- EDIT: **All required pull request tests passed** Provided pull request template: The `run_tests.sh` failed (see below in the collapsed section of the requested pull request guideline template)
    - Regarding the `google test` suite [this helped](https://stackoverflow.com/questions/24295876/cmake-cannot-find-googletest-required-library-in-ubuntu) in case someone else  experiences the same problem, just build the local files and copy to `/usr/lib`
    - Regarding `Error: Unrecognised theme name: 'material'.`: missing mkdoc material [see](https://github.com/squidfunk/mkdocs-material/issues/52) and solve with `pip install mkdocs-material`.

_Note: The `.gitmodules` change to the other branch is only to provide the corresponding changes in one place, if everything looks good the `.gitmodules` I will rebase interactively and remove the change._

------------------------------------------------------------------------------------------------

Pull Request Guidelines

all pull requests should adhere to the [style guide](http://docs.rosflight.org/en/developer_docs/developer-guide/style_guide/)
- **404 error page - not found**

and should pass the unit tests

``` bash
./run_tests.sh
```
Any pull request not adhering to these guidelines will be rejected.

<details>
<summary>
Test results:

</summary>

```bash
(vp37) scripts ./run_tests.sh             
Test 1: Build F1 firmware
Building ROSflight boards/breezy
cd boards/airbourne && make clean
make[1]: Entering directory '/home/flip/workspaces/freelance/open_source/firmware/boards/airbourne'
***** Building with Debug Symbols *****
VPATH = :../../comms/mavlink:../..:../../src:../../lib/turbomath:airbourne/lib/startup:airbourne/lib/CMSIS/CM4/CoreSupport:airbourne/lib/CMSIS/CM4/DeviceSupport/ST/STM32F4xx:airbourne/lib/STM32F4xx_StdPeriph_Driver/src:airbourne/lib/STM32_USB_Device_Library/Core/src:airbourne/lib/STM32_USB_OTG_Driver/src:airbourne/lib/STM32_USB_Device_Library/Class/cdc/src:airbourne/lib/vcp:airbourne/src:../../boards/airbourne:
STARTUP_DIR = airbourne/lib/startup
rm -rf ../../boards/airbourne/build/rosflight/stm32f405.o ../../boards/airbourne/build/rosflight/stm32f4xx_gpio.o ../../boards/airbourne/build/rosflight/stm32f4xx_rcc.o ../../boards/airbourne/build/rosflight/stm32f4xx_gpio.o ../../boards/airbourne/build/rosflight/stm32f4xx_tim.o ../../boards/airbourne/build/rosflight/stm32f4xx_wwdg.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash_sha1.o ../../boards/airbourne/build/rosflight/stm32f4xx_exti.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_tdes.o ../../boards/airbourne/build/rosflight/stm32f4xx_dma.o ../../boards/airbourne/build/rosflight/stm32f4xx_dbgmcu.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash.o ../../boards/airbourne/build/rosflight/stm32f4xx_dac.o ../../boards/airbourne/build/rosflight/stm32f4xx_rtc.o ../../boards/airbourne/build/rosflight/stm32f4xx_pwr.o ../../boards/airbourne/build/rosflight/stm32f4xx_i2c.o ../../boards/airbourne/build/rosflight/stm32f4xx_sdio.o ../../boards/airbourne/build/rosflight/stm32f4xx_rcc.o ../../boards/airbourne/build/rosflight/stm32f4xx_flash.o ../../boards/airbourne/build/rosflight/misc.o ../../boards/airbourne/build/rosflight/stm32f4xx_syscfg.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_des.o ../../boards/airbourne/build/rosflight/stm32f4xx_usart.o ../../boards/airbourne/build/rosflight/stm32f4xx_dcmi.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash_md5.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_aes.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp.o ../../boards/airbourne/build/rosflight/stm32f4xx_rng.o ../../boards/airbourne/build/rosflight/stm32f4xx_iwdg.o ../../boards/airbourne/build/rosflight/stm32f4xx_adc.o ../../boards/airbourne/build/rosflight/stm32f4xx_spi.o ../../boards/airbourne/build/rosflight/usbd_req.o ../../boards/airbourne/build/rosflight/usbd_core.o ../../boards/airbourne/build/rosflight/usbd_ioreq.o ../../boards/airbourne/build/rosflight/usb_dcd_int.o ../../boards/airbourne/build/rosflight/usb_core.o ../../boards/airbourne/build/rosflight/usb_dcd.o ../../boards/airbourne/build/rosflight/usbd_cdc_core.o ../../boards/airbourne/build/rosflight/usbd_desc.o ../../boards/airbourne/build/rosflight/usb_bsp.o ../../boards/airbourne/build/rosflight/usbd_usr.o ../../boards/airbourne/build/rosflight/stm32f4xx_it.o ../../boards/airbourne/build/rosflight/usbd_cdc_vcp.o ../../boards/airbourne/build/rosflight/system.o ../../boards/airbourne/build/rosflight/system_stm32f4xx.o ../../boards/airbourne/build/rosflight/rosflight.o ../../boards/airbourne/build/rosflight/param.o ../../boards/airbourne/build/rosflight/sensors.o ../../boards/airbourne/build/rosflight/state_manager.o ../../boards/airbourne/build/rosflight/estimator.o ../../boards/airbourne/build/rosflight/controller.o ../../boards/airbourne/build/rosflight/comm_manager.o ../../boards/airbourne/build/rosflight/command_manager.o ../../boards/airbourne/build/rosflight/rc.o ../../boards/airbourne/build/rosflight/mixer.o ../../boards/airbourne/build/rosflight/nanoprintf.o ../../boards/airbourne/build/rosflight/turbomath.o ../../boards/airbourne/build/rosflight/mavlink.o ../../boards/airbourne/build/rosflight/led.o ../../boards/airbourne/build/rosflight/gpio.o ../../boards/airbourne/build/rosflight/spi.o ../../boards/airbourne/build/rosflight/vcp.o ../../boards/airbourne/build/rosflight/led.o ../../boards/airbourne/build/rosflight/mpu6000.o ../../boards/airbourne/build/rosflight/advanced.o ../../boards/airbourne/build/rosflight/i2c.o ../../boards/airbourne/build/rosflight/pwm.o ../../boards/airbourne/build/rosflight/mb1242.o ../../boards/airbourne/build/rosflight/eeprom.o ../../boards/airbourne/build/rosflight/hmc5883l.o ../../boards/airbourne/build/rosflight/ms5611.o ../../boards/airbourne/build/rosflight/rc_ppm.o ../../boards/airbourne/build/rosflight/rc_sbus.o ../../boards/airbourne/build/rosflight/uart.o ../../boards/airbourne/build/rosflight/M25P16.o ../../boards/airbourne/build/rosflight/ms4525.o ../../boards/airbourne/build/rosflight/backup_sram.o ../../boards/airbourne/build/rosflight/analog_digital_converter.o ../../boards/airbourne/build/rosflight/analog_pin.o ../../boards/airbourne/build/rosflight/battery_monitor.o ../../boards/airbourne/build/rosflight/ublox.o ../../boards/airbourne/build/rosflight/airbourne_board.o ../../boards/airbourne/build/rosflight/main.o ../../boards/airbourne/build
make[1]: Leaving directory '/home/flip/workspaces/freelance/open_source/firmware/boards/airbourne'
cd boards/breezy && make clean
make[1]: Entering directory '/home/flip/workspaces/freelance/open_source/firmware/boards/breezy'
***** Building with Debug Symbols *****
rm -rf ../../boards/breezy/build/rosflight/startup_stm32f10x_md_gcc.o ../../boards/breezy/build/rosflight/core_cm3.o ../../boards/breezy/build/rosflight/system_stm32f10x.o ../../boards/breezy/build/rosflight/stm32f10x_dma.o ../../boards/breezy/build/rosflight/stm32f10x_dbgmcu.o ../../boards/breezy/build/rosflight/stm32f10x_iwdg.o ../../boards/breezy/build/rosflight/stm32f10x_dac.o ../../boards/breezy/build/rosflight/stm32f10x_can.o ../../boards/breezy/build/rosflight/stm32f10x_rtc.o ../../boards/breezy/build/rosflight/stm32f10x_pwr.o ../../boards/breezy/build/rosflight/stm32f10x_i2c.o ../../boards/breezy/build/rosflight/stm32f10x_sdio.o ../../boards/breezy/build/rosflight/stm32f10x_rcc.o ../../boards/breezy/build/rosflight/stm32f10x_flash.o ../../boards/breezy/build/rosflight/stm32f10x_crc.o ../../boards/breezy/build/rosflight/stm32f10x_usart.o ../../boards/breezy/build/rosflight/stm32f10x_wwdg.o ../../boards/breezy/build/rosflight/stm32f10x_cec.o ../../boards/breezy/build/rosflight/misc.o ../../boards/breezy/build/rosflight/stm32f10x_tim.o ../../boards/breezy/build/rosflight/stm32f10x_adc.o ../../boards/breezy/build/rosflight/stm32f10x_spi.o ../../boards/breezy/build/rosflight/stm32f10x_bkp.o ../../boards/breezy/build/rosflight/stm32f10x_exti.o ../../boards/breezy/build/rosflight/stm32f10x_fsmc.o ../../boards/breezy/build/rosflight/stm32f10x_gpio.o ../../boards/breezy/build/rosflight/drv_gpio.o ../../boards/breezy/build/rosflight/drv_i2c.o ../../boards/breezy/build/rosflight/drv_adc.o ../../boards/breezy/build/rosflight/drv_spi.o ../../boards/breezy/build/rosflight/drv_pwm.o ../../boards/breezy/build/rosflight/drv_system.o ../../boards/breezy/build/rosflight/drv_serial.o ../../boards/breezy/build/rosflight/drv_uart.o ../../boards/breezy/build/rosflight/drv_timer.o ../../boards/breezy/build/rosflight/drv_mpu6050.o ../../boards/breezy/build/rosflight/drv_ms4525.o ../../boards/breezy/build/rosflight/drv_mb1242.o ../../boards/breezy/build/rosflight/drv_ms5611.o ../../boards/breezy/build/rosflight/drv_bmp280.o ../../boards/breezy/build/rosflight/drv_hmc5883l.o ../../boards/breezy/build/rosflight/flash.o ../../boards/breezy/build/rosflight/rosflight.o ../../boards/breezy/build/rosflight/param.o ../../boards/breezy/build/rosflight/sensors.o ../../boards/breezy/build/rosflight/state_manager.o ../../boards/breezy/build/rosflight/estimator.o ../../boards/breezy/build/rosflight/controller.o ../../boards/breezy/build/rosflight/comm_manager.o ../../boards/breezy/build/rosflight/command_manager.o ../../boards/breezy/build/rosflight/rc.o ../../boards/breezy/build/rosflight/mixer.o ../../boards/breezy/build/rosflight/nanoprintf.o ../../boards/breezy/build/rosflight/turbomath.o ../../boards/breezy/build/rosflight/mavlink.o ../../boards/breezy/build/rosflight/breezy_board.o ../../boards/breezy/build/rosflight/main.o 
make[1]: Leaving directory '/home/flip/workspaces/freelance/open_source/firmware/boards/breezy'
Building ROSflight boards/breezy
cd boards/breezy && make -j4 -l4 DEBUG= SERIAL_DEVICE=/dev/ttyACM0
make[1]: Entering directory '/home/flip/workspaces/freelance/open_source/firmware/boards/breezy'
arm-none-eabi-gcc -E  breezystm32/startup_stm32f10x_md_gcc.S > startup_stm32f10x_md_gcc.s
%% core_cm3.c
%% system_stm32f10x.c
%% stm32f10x_dma.c
%% stm32f10x_dbgmcu.c
%% stm32f10x_iwdg.c
%% stm32f10x_dac.c
%% stm32f10x_can.c
%% stm32f10x_rtc.c
%% stm32f10x_pwr.c
%% stm32f10x_i2c.c
%% stm32f10x_sdio.c
%% stm32f10x_rcc.c
%% stm32f10x_flash.c
%% stm32f10x_crc.c
%% stm32f10x_usart.c
%% stm32f10x_wwdg.c
%% stm32f10x_cec.c
%% misc.c
%% stm32f10x_tim.c
%% stm32f10x_adc.c
%% stm32f10x_spi.c
%% stm32f10x_bkp.c
%% stm32f10x_exti.c
%% stm32f10x_fsmc.c
%% stm32f10x_gpio.c
%% drv_gpio.c
%% drv_i2c.c
%% drv_adc.c
%% drv_spi.c
%% drv_pwm.c
%% drv_system.c
%% drv_serial.c
%% drv_uart.c
%% drv_timer.c
%% drv_mpu6050.c
%% drv_ms4525.c
%% drv_mb1242.c
%% drv_ms5611.c
%% drv_bmp280.c
%% drv_hmc5883l.c
%% flash.c
%% rosflight.cpp
%% param.cpp
%% sensors.cpp
%% state_manager.cpp
%% estimator.cpp
%% controller.cpp
%% comm_manager.cpp
%% command_manager.cpp
%% rc.cpp
%% mixer.cpp
%% nanoprintf.cpp
%% turbomath.cpp
%% mavlink.cpp
%% breezy_board.cpp
%% main.cpp
%% startup_stm32f10x_md_gcc.s
arm-none-eabi-g++ -o ../../boards/breezy/build/rosflight_NAZE_Release.elf ../../boards/breezy/build/rosflight/startup_stm32f10x_md_gcc.o ../../boards/breezy/build/rosflight/core_cm3.o ../../boards/breezy/build/rosflight/system_stm32f10x.o ../../boards/breezy/build/rosflight/stm32f10x_dma.o ../../boards/breezy/build/rosflight/stm32f10x_dbgmcu.o ../../boards/breezy/build/rosflight/stm32f10x_iwdg.o ../../boards/breezy/build/rosflight/stm32f10x_dac.o ../../boards/breezy/build/rosflight/stm32f10x_can.o ../../boards/breezy/build/rosflight/stm32f10x_rtc.o ../../boards/breezy/build/rosflight/stm32f10x_pwr.o ../../boards/breezy/build/rosflight/stm32f10x_i2c.o ../../boards/breezy/build/rosflight/stm32f10x_sdio.o ../../boards/breezy/build/rosflight/stm32f10x_rcc.o ../../boards/breezy/build/rosflight/stm32f10x_flash.o ../../boards/breezy/build/rosflight/stm32f10x_crc.o ../../boards/breezy/build/rosflight/stm32f10x_usart.o ../../boards/breezy/build/rosflight/stm32f10x_wwdg.o ../../boards/breezy/build/rosflight/stm32f10x_cec.o ../../boards/breezy/build/rosflight/misc.o ../../boards/breezy/build/rosflight/stm32f10x_tim.o ../../boards/breezy/build/rosflight/stm32f10x_adc.o ../../boards/breezy/build/rosflight/stm32f10x_spi.o ../../boards/breezy/build/rosflight/stm32f10x_bkp.o ../../boards/breezy/build/rosflight/stm32f10x_exti.o ../../boards/breezy/build/rosflight/stm32f10x_fsmc.o ../../boards/breezy/build/rosflight/stm32f10x_gpio.o ../../boards/breezy/build/rosflight/drv_gpio.o ../../boards/breezy/build/rosflight/drv_i2c.o ../../boards/breezy/build/rosflight/drv_adc.o ../../boards/breezy/build/rosflight/drv_spi.o ../../boards/breezy/build/rosflight/drv_pwm.o ../../boards/breezy/build/rosflight/drv_system.o ../../boards/breezy/build/rosflight/drv_serial.o ../../boards/breezy/build/rosflight/drv_uart.o ../../boards/breezy/build/rosflight/drv_timer.o ../../boards/breezy/build/rosflight/drv_mpu6050.o ../../boards/breezy/build/rosflight/drv_ms4525.o ../../boards/breezy/build/rosflight/drv_mb1242.o ../../boards/breezy/build/rosflight/drv_ms5611.o ../../boards/breezy/build/rosflight/drv_bmp280.o ../../boards/breezy/build/rosflight/drv_hmc5883l.o ../../boards/breezy/build/rosflight/flash.o ../../boards/breezy/build/rosflight/rosflight.o ../../boards/breezy/build/rosflight/param.o ../../boards/breezy/build/rosflight/sensors.o ../../boards/breezy/build/rosflight/state_manager.o ../../boards/breezy/build/rosflight/estimator.o ../../boards/breezy/build/rosflight/controller.o ../../boards/breezy/build/rosflight/comm_manager.o ../../boards/breezy/build/rosflight/command_manager.o ../../boards/breezy/build/rosflight/rc.o ../../boards/breezy/build/rosflight/mixer.o ../../boards/breezy/build/rosflight/nanoprintf.o ../../boards/breezy/build/rosflight/turbomath.o ../../boards/breezy/build/rosflight/mavlink.o ../../boards/breezy/build/rosflight/breezy_board.o ../../boards/breezy/build/rosflight/main.o -T breezystm32/stm32_flash.ld -mcpu=cortex-m3 -mthumb -lm -lc --specs=nano.specs --specs=rdimon.specs   -flto -fuse-linker-plugin -O2  -ggdb -static  -Wl,-gc-sections
arm-none-eabi-size ../../boards/breezy/build/rosflight_NAZE_Release.elf
   text	   data	    bss	    dec	    hex	filename
  74904	    168	   4600	  79672	  13738	../../boards/breezy/build/rosflight_NAZE_Release.elf
arm-none-eabi-objcopy -O ihex --set-start 0x8000000 ../../boards/breezy/build/rosflight_NAZE_Release.elf ../../boards/breezy/build/rosflight_NAZE_Release.hex
arm-none-eabi-objcopy -I ihex -O binary ../../boards/breezy/build/rosflight_NAZE_Release.hex ../../boards/breezy/build/rosflight_NAZE_Release.bin
rm startup_stm32f10x_md_gcc.s
make[1]: Leaving directory '/home/flip/workspaces/freelance/open_source/firmware/boards/breezy'
[Passed]

Test 2: Build F4 firmware
Building ROSflight boards/airbourne
cd boards/airbourne && make clean
make[1]: Entering directory '/home/flip/workspaces/freelance/open_source/firmware/boards/airbourne'
***** Building with Debug Symbols *****
VPATH = :../../comms/mavlink:../..:../../src:../../lib/turbomath:airbourne/lib/startup:airbourne/lib/CMSIS/CM4/CoreSupport:airbourne/lib/CMSIS/CM4/DeviceSupport/ST/STM32F4xx:airbourne/lib/STM32F4xx_StdPeriph_Driver/src:airbourne/lib/STM32_USB_Device_Library/Core/src:airbourne/lib/STM32_USB_OTG_Driver/src:airbourne/lib/STM32_USB_Device_Library/Class/cdc/src:airbourne/lib/vcp:airbourne/src:../../boards/airbourne:
STARTUP_DIR = airbourne/lib/startup
rm -rf ../../boards/airbourne/build/rosflight/stm32f405.o ../../boards/airbourne/build/rosflight/stm32f4xx_gpio.o ../../boards/airbourne/build/rosflight/stm32f4xx_rcc.o ../../boards/airbourne/build/rosflight/stm32f4xx_gpio.o ../../boards/airbourne/build/rosflight/stm32f4xx_tim.o ../../boards/airbourne/build/rosflight/stm32f4xx_wwdg.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash_sha1.o ../../boards/airbourne/build/rosflight/stm32f4xx_exti.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_tdes.o ../../boards/airbourne/build/rosflight/stm32f4xx_dma.o ../../boards/airbourne/build/rosflight/stm32f4xx_dbgmcu.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash.o ../../boards/airbourne/build/rosflight/stm32f4xx_dac.o ../../boards/airbourne/build/rosflight/stm32f4xx_rtc.o ../../boards/airbourne/build/rosflight/stm32f4xx_pwr.o ../../boards/airbourne/build/rosflight/stm32f4xx_i2c.o ../../boards/airbourne/build/rosflight/stm32f4xx_sdio.o ../../boards/airbourne/build/rosflight/stm32f4xx_rcc.o ../../boards/airbourne/build/rosflight/stm32f4xx_flash.o ../../boards/airbourne/build/rosflight/misc.o ../../boards/airbourne/build/rosflight/stm32f4xx_syscfg.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_des.o ../../boards/airbourne/build/rosflight/stm32f4xx_usart.o ../../boards/airbourne/build/rosflight/stm32f4xx_dcmi.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash_md5.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_aes.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp.o ../../boards/airbourne/build/rosflight/stm32f4xx_rng.o ../../boards/airbourne/build/rosflight/stm32f4xx_iwdg.o ../../boards/airbourne/build/rosflight/stm32f4xx_adc.o ../../boards/airbourne/build/rosflight/stm32f4xx_spi.o ../../boards/airbourne/build/rosflight/usbd_req.o ../../boards/airbourne/build/rosflight/usbd_core.o ../../boards/airbourne/build/rosflight/usbd_ioreq.o ../../boards/airbourne/build/rosflight/usb_dcd_int.o ../../boards/airbourne/build/rosflight/usb_core.o ../../boards/airbourne/build/rosflight/usb_dcd.o ../../boards/airbourne/build/rosflight/usbd_cdc_core.o ../../boards/airbourne/build/rosflight/usbd_desc.o ../../boards/airbourne/build/rosflight/usb_bsp.o ../../boards/airbourne/build/rosflight/usbd_usr.o ../../boards/airbourne/build/rosflight/stm32f4xx_it.o ../../boards/airbourne/build/rosflight/usbd_cdc_vcp.o ../../boards/airbourne/build/rosflight/system.o ../../boards/airbourne/build/rosflight/system_stm32f4xx.o ../../boards/airbourne/build/rosflight/rosflight.o ../../boards/airbourne/build/rosflight/param.o ../../boards/airbourne/build/rosflight/sensors.o ../../boards/airbourne/build/rosflight/state_manager.o ../../boards/airbourne/build/rosflight/estimator.o ../../boards/airbourne/build/rosflight/controller.o ../../boards/airbourne/build/rosflight/comm_manager.o ../../boards/airbourne/build/rosflight/command_manager.o ../../boards/airbourne/build/rosflight/rc.o ../../boards/airbourne/build/rosflight/mixer.o ../../boards/airbourne/build/rosflight/nanoprintf.o ../../boards/airbourne/build/rosflight/turbomath.o ../../boards/airbourne/build/rosflight/mavlink.o ../../boards/airbourne/build/rosflight/led.o ../../boards/airbourne/build/rosflight/gpio.o ../../boards/airbourne/build/rosflight/spi.o ../../boards/airbourne/build/rosflight/vcp.o ../../boards/airbourne/build/rosflight/led.o ../../boards/airbourne/build/rosflight/mpu6000.o ../../boards/airbourne/build/rosflight/advanced.o ../../boards/airbourne/build/rosflight/i2c.o ../../boards/airbourne/build/rosflight/pwm.o ../../boards/airbourne/build/rosflight/mb1242.o ../../boards/airbourne/build/rosflight/eeprom.o ../../boards/airbourne/build/rosflight/hmc5883l.o ../../boards/airbourne/build/rosflight/ms5611.o ../../boards/airbourne/build/rosflight/rc_ppm.o ../../boards/airbourne/build/rosflight/rc_sbus.o ../../boards/airbourne/build/rosflight/uart.o ../../boards/airbourne/build/rosflight/M25P16.o ../../boards/airbourne/build/rosflight/ms4525.o ../../boards/airbourne/build/rosflight/backup_sram.o ../../boards/airbourne/build/rosflight/analog_digital_converter.o ../../boards/airbourne/build/rosflight/analog_pin.o ../../boards/airbourne/build/rosflight/battery_monitor.o ../../boards/airbourne/build/rosflight/ublox.o ../../boards/airbourne/build/rosflight/airbourne_board.o ../../boards/airbourne/build/rosflight/main.o ../../boards/airbourne/build
make[1]: Leaving directory '/home/flip/workspaces/freelance/open_source/firmware/boards/airbourne'
cd boards/breezy && make clean
make[1]: Entering directory '/home/flip/workspaces/freelance/open_source/firmware/boards/breezy'
***** Building with Debug Symbols *****
rm -rf ../../boards/breezy/build/rosflight/startup_stm32f10x_md_gcc.o ../../boards/breezy/build/rosflight/core_cm3.o ../../boards/breezy/build/rosflight/system_stm32f10x.o ../../boards/breezy/build/rosflight/stm32f10x_dma.o ../../boards/breezy/build/rosflight/stm32f10x_dbgmcu.o ../../boards/breezy/build/rosflight/stm32f10x_iwdg.o ../../boards/breezy/build/rosflight/stm32f10x_dac.o ../../boards/breezy/build/rosflight/stm32f10x_can.o ../../boards/breezy/build/rosflight/stm32f10x_rtc.o ../../boards/breezy/build/rosflight/stm32f10x_pwr.o ../../boards/breezy/build/rosflight/stm32f10x_i2c.o ../../boards/breezy/build/rosflight/stm32f10x_sdio.o ../../boards/breezy/build/rosflight/stm32f10x_rcc.o ../../boards/breezy/build/rosflight/stm32f10x_flash.o ../../boards/breezy/build/rosflight/stm32f10x_crc.o ../../boards/breezy/build/rosflight/stm32f10x_usart.o ../../boards/breezy/build/rosflight/stm32f10x_wwdg.o ../../boards/breezy/build/rosflight/stm32f10x_cec.o ../../boards/breezy/build/rosflight/misc.o ../../boards/breezy/build/rosflight/stm32f10x_tim.o ../../boards/breezy/build/rosflight/stm32f10x_adc.o ../../boards/breezy/build/rosflight/stm32f10x_spi.o ../../boards/breezy/build/rosflight/stm32f10x_bkp.o ../../boards/breezy/build/rosflight/stm32f10x_exti.o ../../boards/breezy/build/rosflight/stm32f10x_fsmc.o ../../boards/breezy/build/rosflight/stm32f10x_gpio.o ../../boards/breezy/build/rosflight/drv_gpio.o ../../boards/breezy/build/rosflight/drv_i2c.o ../../boards/breezy/build/rosflight/drv_adc.o ../../boards/breezy/build/rosflight/drv_spi.o ../../boards/breezy/build/rosflight/drv_pwm.o ../../boards/breezy/build/rosflight/drv_system.o ../../boards/breezy/build/rosflight/drv_serial.o ../../boards/breezy/build/rosflight/drv_uart.o ../../boards/breezy/build/rosflight/drv_timer.o ../../boards/breezy/build/rosflight/drv_mpu6050.o ../../boards/breezy/build/rosflight/drv_ms4525.o ../../boards/breezy/build/rosflight/drv_mb1242.o ../../boards/breezy/build/rosflight/drv_ms5611.o ../../boards/breezy/build/rosflight/drv_bmp280.o ../../boards/breezy/build/rosflight/drv_hmc5883l.o ../../boards/breezy/build/rosflight/flash.o ../../boards/breezy/build/rosflight/rosflight.o ../../boards/breezy/build/rosflight/param.o ../../boards/breezy/build/rosflight/sensors.o ../../boards/breezy/build/rosflight/state_manager.o ../../boards/breezy/build/rosflight/estimator.o ../../boards/breezy/build/rosflight/controller.o ../../boards/breezy/build/rosflight/comm_manager.o ../../boards/breezy/build/rosflight/command_manager.o ../../boards/breezy/build/rosflight/rc.o ../../boards/breezy/build/rosflight/mixer.o ../../boards/breezy/build/rosflight/nanoprintf.o ../../boards/breezy/build/rosflight/turbomath.o ../../boards/breezy/build/rosflight/mavlink.o ../../boards/breezy/build/rosflight/breezy_board.o ../../boards/breezy/build/rosflight/main.o 
make[1]: Leaving directory '/home/flip/workspaces/freelance/open_source/firmware/boards/breezy'
Building ROSflight boards/airbourne
cd boards/airbourne && make -j4 -l4 DEBUG= SERIAL_DEVICE=/dev/ttyACM0
make[1]: Entering directory '/home/flip/workspaces/freelance/open_source/firmware/boards/airbourne'
VPATH = :../../comms/mavlink:../..:../../src:../../lib/turbomath:airbourne/lib/startup:airbourne/lib/CMSIS/CM4/CoreSupport:airbourne/lib/CMSIS/CM4/DeviceSupport/ST/STM32F4xx:airbourne/lib/STM32F4xx_StdPeriph_Driver/src:airbourne/lib/STM32_USB_Device_Library/Core/src:airbourne/lib/STM32_USB_OTG_Driver/src:airbourne/lib/STM32_USB_Device_Library/Class/cdc/src:airbourne/lib/vcp:airbourne/src:../../boards/airbourne:
STARTUP_DIR = airbourne/lib/startup
%% stm32f405.s
%% stm32f4xx_gpio.c
%% stm32f4xx_tim.c
%% stm32f4xx_rcc.c
%% stm32f4xx_wwdg.c
%% stm32f4xx_exti.c
%% stm32f4xx_hash_sha1.c
%% stm32f4xx_cryp_tdes.c
%% stm32f4xx_dma.c
%% stm32f4xx_dbgmcu.c
%% stm32f4xx_hash.c
%% stm32f4xx_dac.c
%% stm32f4xx_rtc.c
%% stm32f4xx_pwr.c
%% stm32f4xx_i2c.c
%% stm32f4xx_sdio.c
%% stm32f4xx_flash.c
%% misc.c
%% stm32f4xx_syscfg.c
%% stm32f4xx_cryp_des.c
%% stm32f4xx_usart.c
%% stm32f4xx_dcmi.c
%% stm32f4xx_hash_md5.c
%% stm32f4xx_cryp_aes.c
%% stm32f4xx_cryp.c
%% stm32f4xx_rng.c
%% stm32f4xx_iwdg.c
%% stm32f4xx_adc.c
%% stm32f4xx_spi.c
%% usbd_req.c
%% usbd_core.c
%% usbd_ioreq.c
%% usb_dcd_int.c
%% usb_core.c
%% usb_dcd.c
%% usbd_cdc_core.c
%% usbd_desc.c
%% usb_bsp.c
%% usbd_usr.c
%% stm32f4xx_it.c
%% usbd_cdc_vcp.c
%% system.c
%% system_stm32f4xx.c
%% rosflight.cpp
%% param.cpp
%% sensors.cpp
%% state_manager.cpp
%% estimator.cpp
%% controller.cpp
%% comm_manager.cpp
%% command_manager.cpp
%% rc.cpp
%% mixer.cpp
%% nanoprintf.cpp
%% turbomath.cpp
%% mavlink.cpp
%% led.cpp
%% gpio.cpp
%% spi.cpp
%% vcp.cpp
%% mpu6000.cpp
%% advanced.cpp
%% i2c.cpp
%% pwm.cpp
%% mb1242.cpp
%% eeprom.cpp
%% hmc5883l.cpp
%% ms5611.cpp
%% rc_ppm.cpp
%% rc_sbus.cpp
%% uart.cpp
%% M25P16.cpp
%% ms4525.cpp
%% backup_sram.cpp
%% analog_digital_converter.cpp
%% analog_pin.cpp
%% battery_monitor.cpp
%% ublox.cpp
%% airbourne_board.cpp
%% main.cpp
arm-none-eabi-g++ -o ../../boards/airbourne/build/rosflight_REVO_Release.elf ../../boards/airbourne/build/rosflight/stm32f405.o ../../boards/airbourne/build/rosflight/stm32f4xx_gpio.o ../../boards/airbourne/build/rosflight/stm32f4xx_rcc.o ../../boards/airbourne/build/rosflight/stm32f4xx_tim.o ../../boards/airbourne/build/rosflight/stm32f4xx_wwdg.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash_sha1.o ../../boards/airbourne/build/rosflight/stm32f4xx_exti.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_tdes.o ../../boards/airbourne/build/rosflight/stm32f4xx_dma.o ../../boards/airbourne/build/rosflight/stm32f4xx_dbgmcu.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash.o ../../boards/airbourne/build/rosflight/stm32f4xx_dac.o ../../boards/airbourne/build/rosflight/stm32f4xx_rtc.o ../../boards/airbourne/build/rosflight/stm32f4xx_pwr.o ../../boards/airbourne/build/rosflight/stm32f4xx_i2c.o ../../boards/airbourne/build/rosflight/stm32f4xx_sdio.o ../../boards/airbourne/build/rosflight/stm32f4xx_flash.o ../../boards/airbourne/build/rosflight/misc.o ../../boards/airbourne/build/rosflight/stm32f4xx_syscfg.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_des.o ../../boards/airbourne/build/rosflight/stm32f4xx_usart.o ../../boards/airbourne/build/rosflight/stm32f4xx_dcmi.o ../../boards/airbourne/build/rosflight/stm32f4xx_hash_md5.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp_aes.o ../../boards/airbourne/build/rosflight/stm32f4xx_cryp.o ../../boards/airbourne/build/rosflight/stm32f4xx_rng.o ../../boards/airbourne/build/rosflight/stm32f4xx_iwdg.o ../../boards/airbourne/build/rosflight/stm32f4xx_adc.o ../../boards/airbourne/build/rosflight/stm32f4xx_spi.o ../../boards/airbourne/build/rosflight/usbd_req.o ../../boards/airbourne/build/rosflight/usbd_core.o ../../boards/airbourne/build/rosflight/usbd_ioreq.o ../../boards/airbourne/build/rosflight/usb_dcd_int.o ../../boards/airbourne/build/rosflight/usb_core.o ../../boards/airbourne/build/rosflight/usb_dcd.o ../../boards/airbourne/build/rosflight/usbd_cdc_core.o ../../boards/airbourne/build/rosflight/usbd_desc.o ../../boards/airbourne/build/rosflight/usb_bsp.o ../../boards/airbourne/build/rosflight/usbd_usr.o ../../boards/airbourne/build/rosflight/stm32f4xx_it.o ../../boards/airbourne/build/rosflight/usbd_cdc_vcp.o ../../boards/airbourne/build/rosflight/system.o ../../boards/airbourne/build/rosflight/system_stm32f4xx.o ../../boards/airbourne/build/rosflight/rosflight.o ../../boards/airbourne/build/rosflight/param.o ../../boards/airbourne/build/rosflight/sensors.o ../../boards/airbourne/build/rosflight/state_manager.o ../../boards/airbourne/build/rosflight/estimator.o ../../boards/airbourne/build/rosflight/controller.o ../../boards/airbourne/build/rosflight/comm_manager.o ../../boards/airbourne/build/rosflight/command_manager.o ../../boards/airbourne/build/rosflight/rc.o ../../boards/airbourne/build/rosflight/mixer.o ../../boards/airbourne/build/rosflight/nanoprintf.o ../../boards/airbourne/build/rosflight/turbomath.o ../../boards/airbourne/build/rosflight/mavlink.o ../../boards/airbourne/build/rosflight/led.o ../../boards/airbourne/build/rosflight/gpio.o ../../boards/airbourne/build/rosflight/spi.o ../../boards/airbourne/build/rosflight/vcp.o ../../boards/airbourne/build/rosflight/mpu6000.o ../../boards/airbourne/build/rosflight/advanced.o ../../boards/airbourne/build/rosflight/i2c.o ../../boards/airbourne/build/rosflight/pwm.o ../../boards/airbourne/build/rosflight/mb1242.o ../../boards/airbourne/build/rosflight/eeprom.o ../../boards/airbourne/build/rosflight/hmc5883l.o ../../boards/airbourne/build/rosflight/ms5611.o ../../boards/airbourne/build/rosflight/rc_ppm.o ../../boards/airbourne/build/rosflight/rc_sbus.o ../../boards/airbourne/build/rosflight/uart.o ../../boards/airbourne/build/rosflight/M25P16.o ../../boards/airbourne/build/rosflight/ms4525.o ../../boards/airbourne/build/rosflight/backup_sram.o ../../boards/airbourne/build/rosflight/analog_digital_converter.o ../../boards/airbourne/build/rosflight/analog_pin.o ../../boards/airbourne/build/rosflight/battery_monitor.o ../../boards/airbourne/build/rosflight/ublox.o ../../boards/airbourne/build/rosflight/airbourne_board.o ../../boards/airbourne/build/rosflight/main.o -T airbourne/lib/startup/stm32f405.ld -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion -lm -lc --specs=nano.specs --specs=rdimon.specs   -flto -fuse-linker-plugin -O2  -ggdb -static  -Wl,-gc-sections -Wl,-Map=main.map
arm-none-eabi-size ../../boards/airbourne/build/rosflight_REVO_Release.elf
   text	   data	    bss	    dec	    hex	filename
 240152	   1052	  15960	 257164	  3ec8c	../../boards/airbourne/build/rosflight_REVO_Release.elf
arm-none-eabi-objcopy -O ihex --set-start 0x8000000 ../../boards/airbourne/build/rosflight_REVO_Release.elf ../../boards/airbourne/build/rosflight_REVO_Release.hex
arm-none-eabi-objcopy -I ihex -O binary ../../boards/airbourne/build/rosflight_REVO_Release.hex ../../boards/airbourne/build/rosflight_REVO_Release.bin
make[1]: Leaving directory '/home/flip/workspaces/freelance/open_source/firmware/boards/airbourne'
[Passed]

Test 3: Build test suite
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found GTest: /usr/lib/libgtest.a  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/flip/workspaces/freelance/open_source/firmware/test/build
Scanning dependencies of target unit_tests
[ 19%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/state_manager.cpp.o
[ 19%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/rosflight.cpp.o
[ 19%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/sensors.cpp.o
[ 19%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/param.cpp.o
[ 23%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/estimator.cpp.o
[ 28%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/nanoprintf.cpp.o
[ 33%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/controller.cpp.o
[ 38%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/comm_manager.cpp.o
[ 42%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/command_manager.cpp.o
[ 47%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/rc.cpp.o
[ 52%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/src/mixer.cpp.o
[ 57%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/comms/mavlink/mavlink.cpp.o
[ 61%] Building CXX object CMakeFiles/unit_tests.dir/home/flip/workspaces/freelance/open_source/firmware/lib/turbomath/turbomath.cpp.o
[ 66%] Building CXX object CMakeFiles/unit_tests.dir/common.cpp.o
[ 71%] Building CXX object CMakeFiles/unit_tests.dir/command_manager_test.cpp.o
[ 76%] Building CXX object CMakeFiles/unit_tests.dir/test_board.cpp.o
[ 80%] Building CXX object CMakeFiles/unit_tests.dir/turbotrig_test.cpp.o
[ 85%] Building CXX object CMakeFiles/unit_tests.dir/state_machine_test.cpp.o
[ 90%] Building CXX object CMakeFiles/unit_tests.dir/estimator_test.cpp.o
[ 95%] Building CXX object CMakeFiles/unit_tests.dir/parameters_test.cpp.o
[100%] Linking CXX executable unit_tests
[100%] Built target unit_tests
[Passed]

Test 4: Run test suite
[==========] Running 80 tests from 5 test cases.
[----------] Global test environment set-up.
[----------] 25 tests from CommandManagerTest
[ RUN      ] CommandManagerTest.Default
[       OK ] CommandManagerTest.Default (1 ms)
[ RUN      ] CommandManagerTest.RCCommands
[       OK ] CommandManagerTest.RCCommands (0 ms)
[ RUN      ] CommandManagerTest.ArmWithSticksByDefault
[       OK ] CommandManagerTest.ArmWithSticksByDefault (0 ms)
[ RUN      ] CommandManagerTest.DontArmWithSticksWhenUsingSwitch
[       OK ] CommandManagerTest.DontArmWithSticksWhenUsingSwitch (1 ms)
[ RUN      ] CommandManagerTest.DisarmWithSticksByDefault
[       OK ] CommandManagerTest.DisarmWithSticksByDefault (0 ms)
[ RUN      ] CommandManagerTest.ArmWithSwitch
[       OK ] CommandManagerTest.ArmWithSwitch (0 ms)
[ RUN      ] CommandManagerTest.DisarmWithStick
[       OK ] CommandManagerTest.DisarmWithStick (0 ms)
[ RUN      ] CommandManagerTest.DontDisarmWithSticksWhenUsingSwitch
[       OK ] CommandManagerTest.DontDisarmWithSticksWhenUsingSwitch (1 ms)
[ RUN      ] CommandManagerTest.ArmStickReversed
[       OK ] CommandManagerTest.ArmStickReversed (0 ms)
[ RUN      ] CommandManagerTest.DisarmStickReversed
[       OK ] CommandManagerTest.DisarmStickReversed (0 ms)
[ RUN      ] CommandManagerTest.DefaultRCOutputd
[       OK ] CommandManagerTest.DefaultRCOutputd (1 ms)
[ RUN      ] CommandManagerTest.RCOutput
[       OK ] CommandManagerTest.RCOutput (0 ms)
[ RUN      ] CommandManagerTest.LoseRCDisarmed
[       OK ] CommandManagerTest.LoseRCDisarmed (0 ms)
[ RUN      ] CommandManagerTest.RegainRCDisarmed
[       OK ] CommandManagerTest.RegainRCDisarmed (0 ms)
[ RUN      ] CommandManagerTest.LoseRCArmed
[       OK ] CommandManagerTest.LoseRCArmed (0 ms)
[ RUN      ] CommandManagerTest.RegainRCArmed
[       OK ] CommandManagerTest.RegainRCArmed (0 ms)
[ RUN      ] CommandManagerTest.OffboardCommandMuxNoMinThrottle
[       OK ] CommandManagerTest.OffboardCommandMuxNoMinThrottle (1 ms)
[ RUN      ] CommandManagerTest.OffboardCommandMuxMinThrottle
[       OK ] CommandManagerTest.OffboardCommandMuxMinThrottle (0 ms)
[ RUN      ] CommandManagerTest.OffboardCommandMuxRollDeviation
[       OK ] CommandManagerTest.OffboardCommandMuxRollDeviation (1 ms)
[ RUN      ] CommandManagerTest.OffboardCommandMuxPitchDeviation
[       OK ] CommandManagerTest.OffboardCommandMuxPitchDeviation (0 ms)
[ RUN      ] CommandManagerTest.OffboardCommandMuxYawrateDeviation
[       OK ] CommandManagerTest.OffboardCommandMuxYawrateDeviation (1 ms)
[ RUN      ] CommandManagerTest.OffboardCommandMuxLag
[       OK ] CommandManagerTest.OffboardCommandMuxLag (1 ms)
[ RUN      ] CommandManagerTest.StaleOffboardCommand
[       OK ] CommandManagerTest.StaleOffboardCommand (1 ms)
[ RUN      ] CommandManagerTest.PartialMux
[       OK ] CommandManagerTest.PartialMux (1 ms)
[ RUN      ] CommandManagerTest.MixedTypes
[       OK ] CommandManagerTest.MixedTypes (1 ms)
[----------] 25 tests from CommandManagerTest (11 ms total)

[----------] 8 tests from TurboMath
[ RUN      ] TurboMath.atan
[       OK ] TurboMath.atan (28 ms)
[ RUN      ] TurboMath.sin_cos
[       OK ] TurboMath.sin_cos (95 ms)
[ RUN      ] TurboMath.atan2
[       OK ] TurboMath.atan2 (198 ms)
[ RUN      ] TurboMath.asin
[       OK ] TurboMath.asin (0 ms)
[ RUN      ] TurboMath.fastAlt
[       OK ] TurboMath.fastAlt (3 ms)
[ RUN      ] TurboMath.Vector
[       OK ] TurboMath.Vector (0 ms)
[ RUN      ] TurboMath.Quaternion
[       OK ] TurboMath.Quaternion (0 ms)
[ RUN      ] TurboMath.QuatFromTwoVectors
[       OK ] TurboMath.QuatFromTwoVectors (0 ms)
[----------] 8 tests from TurboMath (324 ms total)

[----------] 37 tests from StateMachineTest
[ RUN      ] StateMachineTest.Init
[       OK ] StateMachineTest.Init (1 ms)
[ RUN      ] StateMachineTest.SetAndClearAllErrors
[       OK ] StateMachineTest.SetAndClearAllErrors (0 ms)
[ RUN      ] StateMachineTest.SetAndClearComboErrors
[       OK ] StateMachineTest.SetAndClearComboErrors (0 ms)
[ RUN      ] StateMachineTest.AddErrorAfterPreviousError
[       OK ] StateMachineTest.AddErrorAfterPreviousError (0 ms)
[ RUN      ] StateMachineTest.ClearOneErrorOutOfMany
[       OK ] StateMachineTest.ClearOneErrorOutOfMany (0 ms)
[ RUN      ] StateMachineTest.ClearMultipleErrorsAtOnce
[       OK ] StateMachineTest.ClearMultipleErrorsAtOnce (0 ms)
[ RUN      ] StateMachineTest.ClearAllErrors
[       OK ] StateMachineTest.ClearAllErrors (0 ms)
[ RUN      ] StateMachineTest.DoNotArmIfError
[       OK ] StateMachineTest.DoNotArmIfError (0 ms)
[ RUN      ] StateMachineTest.ArmIfNoError
[       OK ] StateMachineTest.ArmIfNoError (0 ms)
[ RUN      ] StateMachineTest.ArmAndDisarm
[       OK ] StateMachineTest.ArmAndDisarm (0 ms)
[ RUN      ] StateMachineTest.WaitForCalibrationToArm
[       OK ] StateMachineTest.WaitForCalibrationToArm (0 ms)
[ RUN      ] StateMachineTest.CalibrationFailedDontArm
[       OK ] StateMachineTest.CalibrationFailedDontArm (0 ms)
[ RUN      ] StateMachineTest.ErrorDuringCalibrationDontArm
[       OK ] StateMachineTest.ErrorDuringCalibrationDontArm (0 ms)
[ RUN      ] StateMachineTest.RCLostDuringCalibrationDontArm
[       OK ] StateMachineTest.RCLostDuringCalibrationDontArm (1 ms)
[ RUN      ] StateMachineTest.ClearErrorStayDisarmed
[       OK ] StateMachineTest.ClearErrorStayDisarmed (0 ms)
[ RUN      ] StateMachineTest.RecoverRCStayDisarmed
[       OK ] StateMachineTest.RecoverRCStayDisarmed (0 ms)
[ RUN      ] StateMachineTest.SetErrorsWhileArmed
[       OK ] StateMachineTest.SetErrorsWhileArmed (0 ms)
[ RUN      ] StateMachineTest.ErrorsPersistWhenDisarmed
[       OK ] StateMachineTest.ErrorsPersistWhenDisarmed (0 ms)
[ RUN      ] StateMachineTest.UnableToArmWithPersistentErrors
[       OK ] StateMachineTest.UnableToArmWithPersistentErrors (0 ms)
[ RUN      ] StateMachineTest.ArmIfThrottleLow
[       OK ] StateMachineTest.ArmIfThrottleLow (0 ms)
[ RUN      ] StateMachineTest.ArmIfThrottleHighWithMinThrottle
[       OK ] StateMachineTest.ArmIfThrottleHighWithMinThrottle (1 ms)
[ RUN      ] StateMachineTest.DontArmIfThrottleHighWithoutMinThrottle
[       OK ] StateMachineTest.DontArmIfThrottleHighWithoutMinThrottle (0 ms)
[ RUN      ] StateMachineTest.LostRCWhenDisarmNoFailsafe
[       OK ] StateMachineTest.LostRCWhenDisarmNoFailsafe (0 ms)
[ RUN      ] StateMachineTest.UnableToArmWithoutRC
[       OK ] StateMachineTest.UnableToArmWithoutRC (1 ms)
[ RUN      ] StateMachineTest.AbleToArmAfterRCRecovery
[       OK ] StateMachineTest.AbleToArmAfterRCRecovery (0 ms)
[ RUN      ] StateMachineTest.RCLostWhileArmedEnterFailsafe
[       OK ] StateMachineTest.RCLostWhileArmedEnterFailsafe (0 ms)
[ RUN      ] StateMachineTest.DisarmWhileInFailsafeGoToError
[       OK ] StateMachineTest.DisarmWhileInFailsafeGoToError (0 ms)
[ RUN      ] StateMachineTest.RegainRCAfterFailsafe
[       OK ] StateMachineTest.RegainRCAfterFailsafe (0 ms)
[ RUN      ] StateMachineTest.NormalBoot
[       OK ] StateMachineTest.NormalBoot (0 ms)
[ RUN      ] StateMachineTest.CrashRecoveryDisarmed
[       OK ] StateMachineTest.CrashRecoveryDisarmed (0 ms)
[ RUN      ] StateMachineTest.CrashRecoveryArmed
[       OK ] StateMachineTest.CrashRecoveryArmed (0 ms)
[ RUN      ] StateMachineTest.CrashRecoveryInvalidChecksum
[       OK ] StateMachineTest.CrashRecoveryInvalidChecksum (0 ms)
[ RUN      ] StateMachineTest.CrashRecoveryInvalidArmMagic
[       OK ] StateMachineTest.CrashRecoveryInvalidArmMagic (0 ms)
[ RUN      ] StateMachineTest.WriteBackupDataDisarmed
[       OK ] StateMachineTest.WriteBackupDataDisarmed (0 ms)
[ RUN      ] StateMachineTest.WriteBackupDataArmed
[       OK ] StateMachineTest.WriteBackupDataArmed (0 ms)
[ RUN      ] StateMachineTest.DoNotArmIfInvalidFailsafe
[       OK ] StateMachineTest.DoNotArmIfInvalidFailsafe (0 ms)
[ RUN      ] StateMachineTest.ArmAfterCorrectFailsafe
[       OK ] StateMachineTest.ArmAfterCorrectFailsafe (0 ms)
[----------] 37 tests from StateMachineTest (4 ms total)

[----------] 9 tests from EstimatorTest
[ RUN      ] EstimatorTest.LinearGyro
[       OK ] EstimatorTest.LinearGyro (49 ms)
[ RUN      ] EstimatorTest.QuadraticGyro
[       OK ] EstimatorTest.QuadraticGyro (49 ms)
[ RUN      ] EstimatorTest.MatrixExp
[       OK ] EstimatorTest.MatrixExp (49 ms)
[ RUN      ] EstimatorTest.MatrixExpQuadInt
[       OK ] EstimatorTest.MatrixExpQuadInt (50 ms)
[ RUN      ] EstimatorTest.Accel
[       OK ] EstimatorTest.Accel (53 ms)
[ RUN      ] EstimatorTest.EstimateStateAccel
[       OK ] EstimatorTest.EstimateStateAccel (106 ms)
[ RUN      ] EstimatorTest.EstimateBiasAccel
[       OK ] EstimatorTest.EstimateBiasAccel (112 ms)
[ RUN      ] EstimatorTest.StaticExtAtt
[       OK ] EstimatorTest.StaticExtAtt (95 ms)
[ RUN      ] EstimatorTest.MovingExtAtt
[       OK ] EstimatorTest.MovingExtAtt (108 ms)
[----------] 9 tests from EstimatorTest (671 ms total)

[----------] 1 test from Parameters
[ RUN      ] Parameters.DefaultParameters
[       OK ] Parameters.DefaultParameters (0 ms)
[----------] 1 test from Parameters (0 ms total)

[----------] Global test environment tear-down
[==========] 80 tests from 5 test cases ran. (1010 ms total)
[  PASSED  ] 80 tests.
[Passed]

Test 5: Build MkDocs documentation
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/flip/workspaces/freelance/open_source/firmware/site 
INFO    -  Documentation built in 1.40 seconds 
[Passed]

All tests passed!

```

</details>