### PR TITLE
Removed outlier filters and artifacts

### DIFF
--- a/include/sensors.h
+++ b/include/sensors.h
@@ -149,12 +149,10 @@ public:
     float diff_pressure_velocity = 0;
     float diff_pressure = 0;
     float diff_pressure_temp = 0;
-  //  bool diff_pressure_valid = false;
 
     float baro_altitude = 0;
     float baro_pressure = 0;
     float baro_temperature = 0;
-  //  bool baro_valid = false;
 
     float sonar_range = 0;
     bool sonar_range_valid = false;

--- a/include/sensors.h
+++ b/include/sensors.h
@@ -204,17 +204,10 @@ public:
   got_flags got;
 
 private:
-  static const float BARO_MAX_CHANGE_RATE;
-  static const float BARO_SAMPLE_RATE;
-  static const float DIFF_MAX_CHANGE_RATE;
-  static const float DIFF_SAMPLE_RATE;
-  static const float SONAR_MAX_CHANGE_RATE;
-  static const float SONAR_SAMPLE_RATE;
   static const int SENSOR_CAL_DELAY_CYCLES;
   static const int SENSOR_CAL_CYCLES;
   static const float BARO_MAX_CALIBRATION_VARIANCE;
   static const float DIFF_PRESSURE_MAX_CALIBRATION_VARIANCE;
-  static constexpr uint32_t BATTERY_MONITOR_UPDATE_PERIOD_MS = 10;
 
   enum : uint8_t
   {

--- a/include/sensors.h
+++ b/include/sensors.h
@@ -149,12 +149,12 @@ public:
     float diff_pressure_velocity = 0;
     float diff_pressure = 0;
     float diff_pressure_temp = 0;
-    bool diff_pressure_valid = false;
+  //  bool diff_pressure_valid = false;
 
     float baro_altitude = 0;
     float baro_pressure = 0;
     float baro_temperature = 0;
-    bool baro_valid = false;
+  //  bool baro_valid = false;
 
     float sonar_range = 0;
     bool sonar_range_valid = false;
@@ -215,20 +215,6 @@ private:
   static const float BARO_MAX_CALIBRATION_VARIANCE;
   static const float DIFF_PRESSURE_MAX_CALIBRATION_VARIANCE;
   static constexpr uint32_t BATTERY_MONITOR_UPDATE_PERIOD_MS = 10;
-
-  class OutlierFilter
-  {
-  private:
-    float max_change_;
-    float center_;
-    int window_size_;
-    bool init_ = false;
-
-  public:
-    OutlierFilter() {}
-    void init(float max_change_rate, float update_rate, float center);
-    bool update(float new_val, float * val);
-  };
 
   enum : uint8_t
   {
@@ -301,11 +287,6 @@ private:
   uint32_t last_diff_pressure_cal_iter_ms_ = 0;
   float diff_pressure_calibration_mean_ = 0.0f;
   float diff_pressure_calibration_var_ = 0.0f;
-
-  // Sensor Measurement Outlier Filters
-  OutlierFilter baro_outlier_filt_;
-  OutlierFilter diff_outlier_filt_;
-  OutlierFilter sonar_outlier_filt_;
 
   uint32_t last_battery_monitor_update_ms_ = 0;
   // Battery Monitor

--- a/src/comm_manager.cpp
+++ b/src/comm_manager.cpp
@@ -397,37 +397,30 @@ void CommManager::send_rc_raw(void)
 
 void CommManager::send_diff_pressure(void)
 {
-  if (RF_.sensors_.data().diff_pressure_valid) {
     comm_link_.send_diff_pressure(sysid_, RF_.sensors_.data().diff_pressure_velocity,
                                   RF_.sensors_.data().diff_pressure,
                                   RF_.sensors_.data().diff_pressure_temp);
   }
-}
 
 void CommManager::send_baro(void)
 {
-  if (RF_.sensors_.data().baro_valid) {
     comm_link_.send_baro(sysid_, RF_.sensors_.data().baro_altitude,
                          RF_.sensors_.data().baro_pressure, RF_.sensors_.data().baro_temperature);
   }
-}
 
 void CommManager::send_sonar(void)
 {
-  if (RF_.sensors_.data().sonar_range_valid) {
     comm_link_.send_sonar(sysid_,
                           0, // TODO set sensor type (sonar/lidar), use enum
                           RF_.sensors_.data().sonar_range, 8.0, 0.25);
   }
-}
 
 void CommManager::send_mag(void)
 {
-  if (RF_.sensors_.data().mag_present) comm_link_.send_mag(sysid_, RF_.sensors_.data().mag);
+ 	  	  comm_link_.send_mag(sysid_, RF_.sensors_.data().mag);
 }
 void CommManager::send_battery_status(void)
 {
-  if (RF_.sensors_.data().battery_monitor_present)
     comm_link_.send_battery_status(sysid_, RF_.sensors_.data().battery_voltage,
                                    RF_.sensors_.data().battery_current);
 }
@@ -446,24 +439,20 @@ void CommManager::send_gnss(void)
 {
   const GNSSData & gnss_data = RF_.sensors_.data().gnss_data;
 
-  if (RF_.sensors_.data().gnss_present) {
     if (gnss_data.time_of_week != last_sent_gnss_tow_) {
       comm_link_.send_gnss(sysid_, gnss_data);
       last_sent_gnss_tow_ = gnss_data.time_of_week;
     }
   }
-}
 
 void CommManager::send_gnss_full()
 {
   const GNSSFull & gnss_full = RF_.sensors_.data().gnss_full;
 
-  if (RF_.sensors_.data().gnss_present) {
     if (gnss_full.time_of_week != last_sent_gnss_full_tow_) {
       comm_link_.send_gnss_full(sysid_, RF_.sensors_.data().gnss_full);
       last_sent_gnss_full_tow_ = gnss_full.time_of_week;
     }
-  }
 }
 
 void CommManager::send_low_priority(void)

--- a/src/comm_manager.cpp
+++ b/src/comm_manager.cpp
@@ -397,32 +397,29 @@ void CommManager::send_rc_raw(void)
 
 void CommManager::send_diff_pressure(void)
 {
-    comm_link_.send_diff_pressure(sysid_, RF_.sensors_.data().diff_pressure_velocity,
-                                  RF_.sensors_.data().diff_pressure,
-                                  RF_.sensors_.data().diff_pressure_temp);
-  }
+  comm_link_.send_diff_pressure(sysid_, RF_.sensors_.data().diff_pressure_velocity,
+                                RF_.sensors_.data().diff_pressure,
+                                RF_.sensors_.data().diff_pressure_temp);
+}
 
 void CommManager::send_baro(void)
 {
-    comm_link_.send_baro(sysid_, RF_.sensors_.data().baro_altitude,
-                         RF_.sensors_.data().baro_pressure, RF_.sensors_.data().baro_temperature);
-  }
+  comm_link_.send_baro(sysid_, RF_.sensors_.data().baro_altitude, RF_.sensors_.data().baro_pressure,
+                       RF_.sensors_.data().baro_temperature);
+}
 
 void CommManager::send_sonar(void)
 {
-    comm_link_.send_sonar(sysid_,
-                          0, // TODO set sensor type (sonar/lidar), use enum
-                          RF_.sensors_.data().sonar_range, 8.0, 0.25);
-  }
-
-void CommManager::send_mag(void)
-{
- 	  	  comm_link_.send_mag(sysid_, RF_.sensors_.data().mag);
+  comm_link_.send_sonar(sysid_,
+                        0, // TODO set sensor type (sonar/lidar), use enum
+                        RF_.sensors_.data().sonar_range, 8.0, 0.25);
 }
+
+void CommManager::send_mag(void) { comm_link_.send_mag(sysid_, RF_.sensors_.data().mag); }
 void CommManager::send_battery_status(void)
 {
-    comm_link_.send_battery_status(sysid_, RF_.sensors_.data().battery_voltage,
-                                   RF_.sensors_.data().battery_current);
+  comm_link_.send_battery_status(sysid_, RF_.sensors_.data().battery_voltage,
+                                 RF_.sensors_.data().battery_current);
 }
 
 void CommManager::send_backup_data(const StateManager::BackupData & backup_data)
@@ -439,20 +436,20 @@ void CommManager::send_gnss(void)
 {
   const GNSSData & gnss_data = RF_.sensors_.data().gnss_data;
 
-    if (gnss_data.time_of_week != last_sent_gnss_tow_) {
-      comm_link_.send_gnss(sysid_, gnss_data);
-      last_sent_gnss_tow_ = gnss_data.time_of_week;
-    }
+  if (gnss_data.time_of_week != last_sent_gnss_tow_) {
+    comm_link_.send_gnss(sysid_, gnss_data);
+    last_sent_gnss_tow_ = gnss_data.time_of_week;
   }
+}
 
 void CommManager::send_gnss_full()
 {
   const GNSSFull & gnss_full = RF_.sensors_.data().gnss_full;
 
-    if (gnss_full.time_of_week != last_sent_gnss_full_tow_) {
-      comm_link_.send_gnss_full(sysid_, RF_.sensors_.data().gnss_full);
-      last_sent_gnss_full_tow_ = gnss_full.time_of_week;
-    }
+  if (gnss_full.time_of_week != last_sent_gnss_full_tow_) {
+    comm_link_.send_gnss_full(sysid_, RF_.sensors_.data().gnss_full);
+    last_sent_gnss_full_tow_ = gnss_full.time_of_week;
+  }
 }
 
 void CommManager::send_low_priority(void)

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -44,15 +44,6 @@
 
 namespace rosflight_firmware
 {
-// TODO: These values don't change actual rates, is there a way to just reference actual rates
-//  as defined in hardware board implementation?
-const float Sensors::BARO_MAX_CHANGE_RATE = 200.0f; // approx 200 m/s
-const float Sensors::BARO_SAMPLE_RATE = 50.0f;
-const float Sensors::DIFF_MAX_CHANGE_RATE = 225.0f; // approx 15 m/s^2
-const float Sensors::DIFF_SAMPLE_RATE = 100.0f;
-const float Sensors::SONAR_MAX_CHANGE_RATE = 100.0f; // 100 m/s
-const float Sensors::SONAR_SAMPLE_RATE = 50.0f;
-
 const int Sensors::SENSOR_CAL_DELAY_CYCLES = 128;
 const int Sensors::SENSOR_CAL_CYCLES = 127;
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -172,9 +172,9 @@ got_flags Sensors::run()
     if (rf_.board_.baro_has_new_data()) {
       got.baro = true;
       rf_.board_.baro_read(&data_.baro_pressure, &data_.baro_temperature);
-        correct_baro();
-      }
+      correct_baro();
     }
+  }
 
   // MAGNETOMETER:
   if (rf_.board_.mag_present()) {
@@ -196,9 +196,9 @@ got_flags Sensors::run()
     if (rf_.board_.diff_pressure_has_new_data()) {
       got.diff_pressure = true;
       rf_.board_.diff_pressure_read(&data_.diff_pressure, &data_.diff_pressure_temp);
-        correct_diff_pressure();
-      }
+      correct_diff_pressure();
     }
+  }
 
   // SONAR:
   if (rf_.board_.sonar_present()) {


### PR DESCRIPTION
1. Removed outlier filters. This affects the airspeed, barometer, and sonar.  
2. Removed the (redundant) check for valid data in the comm_manager because those functions are not called unless the data is valid. This affects all send_* functions that have this redundancy.
