### PR TITLE
Firmware doesn't currently print out correct flags for control modes.

### DIFF
--- a/src/comm_manager.cpp
+++ b/src/comm_manager.cpp
@@ -350,7 +350,7 @@ void CommManager::send_status(void)
   if (!initialized_) { return; }
 
   uint8_t control_mode = 0;
-  if (RF_.params_.get_param_int(PARAM_FIXED_WING)) {
+  if (RF_.params_.get_param_int(PARAM_FIXED_WING) || RF_.command_manager_.combined_control().x.type == PASSTHROUGH) {
     control_mode = MODE_PASS_THROUGH;
   } else if (RF_.command_manager_.combined_control().x.type == ANGLE) {
     control_mode = MODE_ROLL_PITCH_YAWRATE_THROTTLE;


### PR DESCRIPTION
The firmware sends status messages to the `rosflight_io` node with information about the current command mode. However, there was no way for a multirotor configuration to print out the correct `PASS_THROUGH` mode string if it was in passthrough mode. This pull request adds a flag to check.