### PR TITLE
Changes pitot velocity to indicated air speed (ias)

### DIFF
--- a/include/sensors.h
+++ b/include/sensors.h
@@ -146,7 +146,7 @@ public:
     float imu_temperature = 0;
     uint64_t imu_time = 0;
 
-    float diff_pressure_velocity = 0;
+    float diff_pressure_ias = 0;
     float diff_pressure = 0;
     float diff_pressure_temp = 0;
 

--- a/src/comm_manager.cpp
+++ b/src/comm_manager.cpp
@@ -404,7 +404,7 @@ void CommManager::send_rc_raw(void)
 
 void CommManager::send_diff_pressure(void)
 {
-  comm_link_.send_diff_pressure(sysid_, RF_.sensors_.data().diff_pressure_velocity,
+  comm_link_.send_diff_pressure(sysid_, RF_.sensors_.data().diff_pressure_ias,
                                 RF_.sensors_.data().diff_pressure,
                                 RF_.sensors_.data().diff_pressure_temp);
 }

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -561,10 +561,9 @@ void Sensors::correct_diff_pressure()
   if (!diff_pressure_calibrated_) { calibrate_diff_pressure(); }
   data_.diff_pressure -= rf_.params_.get_param_float(PARAM_DIFF_PRESS_BIAS);
 
-  float atm = 101325.0f;
-  if (data_.baro_present) { atm = data_.baro_pressure; }
-  data_.diff_pressure_velocity = turbomath::fsign(data_.diff_pressure) * 24.574f
-    / turbomath::inv_sqrt((turbomath::fabs(data_.diff_pressure) * data_.diff_pressure_temp / atm));
+  // compute indicated air speed
+  data_.diff_pressure_ias = turbomath::fsign(data_.diff_pressure)
+    * sqrt((fabs(data_.diff_pressure)/(0.5*1.225)));
 }
 
 void Sensors::update_battery_monitor_multipliers()


### PR DESCRIPTION
Pitot velocity was trying to report the true air speed, but used the pitot sensor's internal temperature and the barometric pressure to compute the density. Unfortunately the pitot sensor temperature is not the atmospheric outside air temperature (OAT).
The computation is changed to compute the indicated air speed (IAS).
