### PR TITLE
Save mixer values to params when canned mixer is selected

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -126,6 +126,8 @@ private:
   float mix_multirotor_with_motor_parameters(Controller::Output commands);
   float mix_multirotor_without_motor_parameters(Controller::Output commands);
   void select_primary_or_secondary_mixer();
+  void save_primary_mixer_params();
+  void save_secondary_mixer_params();
 
   // clang-format off
 


### PR DESCRIPTION
## Motivation
This [rosflight_ros_pkgs PR](195-plane-acts-erratically-under-computer-or-manual-control----v-tail-mixer-issues-in-the-simulation) adds the functionality for other nodes to query `rosflight_io` for the current values of the firmware parameters. 

Previously, the canned mixer types were not stored in the firmware's parameters, so `rosflight_io` had no idea what the correct mixer parameters were when a canned mixer was selected. 

## What I did:
- Added a `save_secondary_mixer_params` and `save_primary_mixer_params` methods to the firmware mixer. When a canned mixer is selected, it now inverts it like normal and then saves those values to the mixer parameters.

Note that this is consistent with how custom mixers are saved -- the "inverted" version is saved to the parameters, which is then directly multiplied by the force vector to get the desired outputs.