### PR TITLE
Secondary mixer param tracking bug

### DIFF
--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -59,6 +59,15 @@ void Mixer::param_change_callback(uint16_t param_id)
 
   if ((param_id >=PARAM_PRIMARY_MIXER_OUTPUT_0 )&&(param_id <=PARAM_PRIMARY_MIXER_5_9 )) {
     load_primary_mixer_values();
+
+    // Check to see if the secondary mixer needs to be updated.
+    // Without a call to init_mixing, the primary and secondary mixer parameters can get out of sync, if
+    // the PARAM_SECONDARY_MIXER is set to an invalid mixer (and thus is defaulting to primary mixer).
+    mixer_type_t mixer_choice = static_cast<mixer_type_t>(RF_.params_.get_param_int(PARAM_SECONDARY_MIXER));
+    if (mixer_choice >= NUM_MIXERS) {
+      secondary_mixer_ = primary_mixer_;
+      save_secondary_mixer_params();
+    }
   } else if ((param_id >=PARAM_SECONDARY_MIXER_0_0 )&&(param_id <=PARAM_SECONDARY_MIXER_5_9 )) {
     load_secondary_mixer_values();
   } else switch (param_id) {


### PR DESCRIPTION
Looking through the changes from the previous mixer PR (I didn't look through them carefully the first time—sorry about that), I noticed a slight deviation from the previous behavior.

The scenario is:
PRIMARY_MIXER = 11 (custom)
SECONDARY_MIXER = 255 (invalid mixer)

Since SECONDARY_MIXER is set to invalid mixer, it should result to a copy of the primary mixer. This is set in the `init_mixing` function, so it works just fine on boot and when we change PRIMARY_ or SECONDARY_MIXER parameters.

However, if we change PRI_MIXER_*_* without calling `init_mixing`, then only the primary mixer values get updated. This causes the secondary mixer to get out of sync with the primary mixer, which is incorrect behavior.

**Use case:**
I am loading mixer parameters from scratch, for example, and I load
1. PRIMARY_MIXER first with `PRIMARY_MIXER = 11`
2. Then load `PRI_MIXER_*_* = ...` params

After step 1, the `primary_mixer_` values should be all zeros (since the params are initialized to zeros). Additionally , the `secondary_mixer_` should be equal to the `primary_mixer_` (all zeros) since we did not  specify the `SECONDARY_MIXER` param, and it defaults to 255.
After step 2, however, the `primary_mixer_` would have the correct values but the `secondary_mixer_` would have all zeros still since it is not being set to the primary mixer outside of the `init_mixing` function, and the `init_mixing` function is no longer being called when the `PRI_MIXER_*_*` values change.

Sorry for the long-winded description. This PR fixes that and sets the `secondary_mixer_` equal to the `primary_mixer_` when a `PRI_MIXER_*_*` parameter is changed, but **only when the `SECONDARY_MIXER` param is set to follow the primary mixer**.
