### PR TITLE
Fix secondary mixer initialization bug

### DIFF
--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -65,7 +65,7 @@ void Mixer::param_change_callback(uint16_t param_id)
 
   } else if ((param_id >=PARAM_PRIMARY_MIXER_PWM_RATE_0 )&&(param_id <=PARAM_PRIMARY_MIXER_PWM_RATE_9 )) {
     primary_mixer_.default_pwm_rate[param_id-PARAM_PRIMARY_MIXER_PWM_RATE_0] = RF_.params_.get_param_float(param_id);
-    // Note: secondary micer pwm rates are not used, but should match the primary mixer in case code elsewhere changes.
+    // Note: secondary mixer pwm rates are not used, but should match the primary mixer in case code elsewhere changes.
     secondary_mixer_.default_pwm_rate[param_id-PARAM_PRIMARY_MIXER_PWM_RATE_0] = RF_.params_.get_param_float(param_id);
 
   } else if ((param_id >=PARAM_PRIMARY_MIXER_0_0 )&&(param_id <=PARAM_PRIMARY_MIXER_5_9 )) {
@@ -73,23 +73,28 @@ void Mixer::param_change_callback(uint16_t param_id)
     uint16_t param_id_offset =  param_id-PARAM_PRIMARY_MIXER_0_0;
     uint16_t param_id_row = param_id_offset%6;
     uint16_t param_id_col = param_id_offset/6;
+    float param_value = RF_.params_.get_param_float(param_id);
 
-    if(param_id_row==0) { primary_mixer_.Fx[param_id_col] = RF_.params_.get_param_float(param_id); }
-    if(param_id_row==1) { primary_mixer_.Fy[param_id_col] = RF_.params_.get_param_float(param_id); }
-    if(param_id_row==2) { primary_mixer_.Fz[param_id_col] = RF_.params_.get_param_float(param_id); }
-    if(param_id_row==3) { primary_mixer_.Qx[param_id_col] = RF_.params_.get_param_float(param_id); }
-    if(param_id_row==4) { primary_mixer_.Qy[param_id_col] = RF_.params_.get_param_float(param_id); }
-    if(param_id_row==5) { primary_mixer_.Qz[param_id_col] = RF_.params_.get_param_float(param_id); }
+    if(param_id_row==0) { primary_mixer_.Fx[param_id_col] = param_value; }
+    if(param_id_row==1) { primary_mixer_.Fy[param_id_col] = param_value; }
+    if(param_id_row==2) { primary_mixer_.Fz[param_id_col] = param_value; }
+    if(param_id_row==3) { primary_mixer_.Qx[param_id_col] = param_value; }
+    if(param_id_row==4) { primary_mixer_.Qy[param_id_col] = param_value; }
+    if(param_id_row==5) { primary_mixer_.Qz[param_id_col] = param_value; }
 
     // Special Case for when secondary mixer is mirroring primary mixer.
     mixer_type_t mixer_choice = static_cast<mixer_type_t>(RF_.params_.get_param_int(PARAM_SECONDARY_MIXER));
     if (mixer_choice >= NUM_MIXERS) {
-      if(param_id_row==0) { secondary_mixer_.Fx[param_id_col] = RF_.params_.get_param_float(param_id); }
-      if(param_id_row==1) { secondary_mixer_.Fy[param_id_col] = RF_.params_.get_param_float(param_id); }
-      if(param_id_row==2) { secondary_mixer_.Fz[param_id_col] = RF_.params_.get_param_float(param_id); }
-      if(param_id_row==3) { secondary_mixer_.Qx[param_id_col] = RF_.params_.get_param_float(param_id); }
-      if(param_id_row==4) { secondary_mixer_.Qy[param_id_col] = RF_.params_.get_param_float(param_id); }
-      if(param_id_row==5) { secondary_mixer_.Qz[param_id_col] = RF_.params_.get_param_float(param_id); }
+      if(param_id_row==0) { secondary_mixer_.Fx[param_id_col] = param_value; }
+      if(param_id_row==1) { secondary_mixer_.Fy[param_id_col] = param_value; }
+      if(param_id_row==2) { secondary_mixer_.Fz[param_id_col] = param_value; }
+      if(param_id_row==3) { secondary_mixer_.Qx[param_id_col] = param_value; }
+      if(param_id_row==4) { secondary_mixer_.Qy[param_id_col] = param_value; }
+      if(param_id_row==5) { secondary_mixer_.Qz[param_id_col] = param_value; }
+
+      // Write the value to params -- otherwise, the secondary mixer gets out of sync
+      uint16_t secondary_mixer_param_id = PARAM_SECONDARY_MIXER_0_0 + param_id_col*6 + param_id_row;
+      RF_.params_.set_param_float(secondary_mixer_param_id, param_value);
     }
 
   } else if ((param_id >=PARAM_SECONDARY_MIXER_0_0 )&&(param_id <=PARAM_SECONDARY_MIXER_5_9 )) {


### PR DESCRIPTION
When the secondary mixer is set to a number greater than NUM_MIXERS (the default for the secondary mixer is 255), then it defaults to have the same values as the primary mixer. 

This PR adds a call to save the value of the secondary mixer to the params after setting the primary mixer value. Without this, the secondary mixer values used in code and the secondary mixer params get out of sync, which is confusing from a user perspective. In this case, the getting the secondary mixer values using the ROS service call does not return the correct value.

The previous workaround was to simply the newly loaded params to file and then restart the firmware, in which case the values for the secondary mixer were loaded properly (since the logic is correct in the `init_mixing` function call).