### PR TITLE
feat: rename sonar_read in board.h to be range_read

### DIFF
--- a/boards/varmint_h7/common/Varmint.cpp
+++ b/boards/varmint_h7/common/Varmint.cpp
@@ -208,9 +208,9 @@ bool Varmint::diff_pressure_read(rosflight_firmware::PressureStruct * diff_press
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 // Sonar
-bool Varmint::sonar_read(rosflight_firmware::RangeStruct * sonar)
+bool Varmint::range_read(rosflight_firmware::RangeStruct * range)
 {
-  (void) sonar; // unused
+  (void) range; // unused
   return false;
 }
 

--- a/boards/varmint_h7/common/Varmint.h
+++ b/boards/varmint_h7/common/Varmint.h
@@ -120,7 +120,7 @@ public:
 
   bool diff_pressure_read(rosflight_firmware::PressureStruct * diff_pressure) override;
 
-  bool sonar_read(rosflight_firmware::RangeStruct * sonar) override;
+  bool range_read(rosflight_firmware::RangeStruct * range) override;
 
   // Battery
   bool battery_read(rosflight_firmware::BatteryStruct * bat) override;

--- a/comms/mavlink/mavlink.cpp
+++ b/comms/mavlink/mavlink.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017, James Jackson and Daniel Koch, BYU MAGICC Lab
  *
  * All rights reserved.
@@ -250,7 +250,7 @@ void Mavlink::send_rc_raw(uint8_t system_id, uint32_t timestamp_ms, const uint16
   send_message(msg);
 }
 
-void Mavlink::send_sonar(uint8_t system_id,
+void Mavlink::send_range(uint8_t system_id,
                          /* TODO enum type*/ uint8_t type, float range, float max_range,
                          float min_range)
 {

--- a/comms/mavlink/mavlink.h
+++ b/comms/mavlink/mavlink.h
@@ -76,7 +76,7 @@ public:
   void send_param_value_float(uint8_t system_id, uint16_t index, const char * const name,
                               float value, uint16_t param_count) override;
   void send_rc_raw(uint8_t system_id, uint32_t timestamp_ms, const uint16_t channels[8]) override;
-  void send_sonar(uint8_t system_id,
+  void send_range(uint8_t system_id,
                   /* TODO enum type*/ uint8_t type, float range, float max_range,
                   float min_range) override;
   void send_status(uint8_t system_id, bool armed, bool failsafe, uint16_t rc_override, bool offboard,

--- a/include/comm_link.h
+++ b/include/comm_link.h
@@ -148,7 +148,7 @@ public:
                                       float value, uint16_t param_count) = 0;
   virtual void send_rc_raw(uint8_t system_id, uint32_t timestamp_ms,
                            const uint16_t channels[8]) = 0;
-  virtual void send_sonar(uint8_t system_id,
+  virtual void send_range(uint8_t system_id,
                           /* TODO enum type*/ uint8_t type, float range, float max_range,
                           float min_range) = 0;
   virtual void send_status(uint8_t system_id, bool armed, bool failsafe, uint16_t rc_override,

--- a/include/comm_manager.h
+++ b/include/comm_manager.h
@@ -151,7 +151,7 @@ private:
   void send_output_raw(void);
   void send_diff_pressure(void);
   void send_baro(void);
-  void send_sonar(void);
+  void send_range(void);
   void send_mag(void);
   void send_battery_status(void);
   void send_gnss(void);

--- a/include/interface/board.h
+++ b/include/interface/board.h
@@ -138,7 +138,7 @@ typedef struct
   bool baro;
   bool mag;
   bool diff_pressure;
-  bool sonar;
+  bool range;
   bool battery;
 } got_flags;
 
@@ -206,7 +206,7 @@ public:
   virtual bool diff_pressure_read(PressureStruct * diff_pressure) = 0;
 
   // Sonar
-  virtual bool sonar_read(RangeStruct * sonar) = 0;
+  virtual bool range_read(RangeStruct * range) = 0;
 
   // GPS
   virtual bool gnss_read(rosflight_firmware::GnssStruct * gnss) = 0;

--- a/include/sensors.h
+++ b/include/sensors.h
@@ -54,7 +54,7 @@ class Sensors : public ParamListenerInterface
 public:
   PressureStruct * get_diff_pressure(void) { return &diff_pressure_; }
   PressureStruct * get_baro(void) { return &baro_; }
-  RangeStruct * get_sonar(void) { return &sonar_; }
+  RangeStruct * get_range(void) { return &range_; }
   ImuStruct * get_imu(void) { return &imu_; }
   BatteryStruct * get_battery(void) { return &battery_; }
   MagStruct * get_mag(void) { return &mag_; }
@@ -79,7 +79,7 @@ private:
   // Data
   PressureStruct diff_pressure_ = {};
   PressureStruct baro_ = {};
-  RangeStruct sonar_ = {};
+  RangeStruct range_ = {};
   ImuStruct imu_ = {};
   BatteryStruct battery_ = {};
   MagStruct mag_ = {};

--- a/src/comm_manager.cpp
+++ b/src/comm_manager.cpp
@@ -419,11 +419,11 @@ void CommManager::send_baro(void)
       RF_.sensors_.get_baro()->temperature);
 }
 
-void CommManager::send_sonar(void)
+void CommManager::send_range(void)
 {
-  comm_link_.send_sonar(sysid_,
+  comm_link_.send_range(sysid_,
                         0, // TODO set sensor type (sonar/lidar), use enum
-                        RF_.sensors_.get_sonar()->range, 8.0, 0.25);
+                        RF_.sensors_.get_range()->range, 8.0, 0.25);
 }
 
 void CommManager::send_mag(void)
@@ -496,7 +496,7 @@ void CommManager::stream(got_flags got)
   // Magnetometer
   if (got.mag) { send_mag(); }
   // Height above ground sensor
-  if (got.sonar) { send_sonar(); }
+  if (got.range) { send_range(); }
   // Battery V & I
   if (got.battery) { send_battery_status(); }
   // GPS data (GNSS Packed)

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -200,7 +200,7 @@ got_flags Sensors::run()
   }
 
   // SONAR:
-  got.sonar = rf_.board_.sonar_read(&sonar_);
+  got.range = rf_.board_.range_read(&range_);
 
   // BATTERY_MONITOR:
   if ((got.battery = rf_.board_.battery_read(&battery_))) {

--- a/test/test_board.cpp
+++ b/test/test_board.cpp
@@ -122,9 +122,9 @@
    return false;
  }
  
- bool testBoard::sonar_read(rosflight_firmware::RangeStruct * sonar)
+ bool testBoard::range_read(rosflight_firmware::RangeStruct * range)
  {
-   (void) sonar;
+   (void) range;
    return false;
  }
  

--- a/test/test_board.h
+++ b/test/test_board.h
@@ -82,7 +82,7 @@
  
    bool diff_pressure_read(rosflight_firmware::PressureStruct * diff_pressure) override;
  
-   bool sonar_read(rosflight_firmware::RangeStruct * sonar) override;
+   bool range_read(rosflight_firmware::RangeStruct * range) override;
  
    // Battery
    bool battery_read(rosflight_firmware::BatteryStruct * bat) override;


### PR DESCRIPTION
Renames sonar_read to range_read in the board.h file, since ROSflight supports both lidar and sonar range measurements.