### PR TITLE
fix: remove exact equality comparison in favor of svd.solve

### DIFF
--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -33,6 +33,7 @@
 
 #include "rosflight.h"
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 
@@ -270,13 +271,16 @@ Mixer::mixer_t Mixer::invert_mixer(const mixer_t* mixer_to_invert)
   Eigen::Matrix<float, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS> mixer_matrix_pinv =
     svd.solve(Eigen::Matrix<float, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS>::Identity());
 
+  constexpr float kMixerZeroThreshold = 1.0e-6f;
+
   mixer_t inverted_mixer;
   // Fill in the mixing matrix from the inverted matrix above
   for (int i = 0; i < NUM_MIXER_OUTPUTS; i++) {
     inverted_mixer.output_type[i] = mixer_to_invert->output_type[i];
     inverted_mixer.default_pwm_rate[i] = mixer_to_invert->default_pwm_rate[i];
     for (int j = 0; j < NUM_MIXER_OUTPUTS; j++) {
-      inverted_mixer.u[j][i] = mixer_matrix_pinv(i, j);
+      float value = mixer_matrix_pinv(i, j);
+      inverted_mixer.u[j][i] = (std::abs(value) < kMixerZeroThreshold) ? 0.0f : value;
     }
   }
   return inverted_mixer;

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -34,6 +34,7 @@
 #include "rosflight.h"
 
 #include <cstdint>
+#include <limits>
 
 namespace rosflight_firmware
 {
@@ -260,21 +261,14 @@ Mixer::mixer_t Mixer::invert_mixer(const mixer_t* mixer_to_invert)
     }
   }
 
-  // Calculate the pseudoinverse of the mixing matrix using the SVD
+  // Calculate the pseudoinverse of the mixing matrix using the SVD.
   Eigen::JacobiSVD<Eigen::Matrix<float, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS>> svd(
     mixer_matrix,
     Eigen::FullPivHouseholderQRPreconditioner | Eigen::ComputeFullU | Eigen::ComputeFullV);
-  Eigen::Matrix<float, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS> Sig;
-  Sig.setZero();
 
-  // Avoid dividing by zero in the Sigma matrix
-  for (int i=0; i<NUM_MIXER_OUTPUTS; ++i) {
-    if (svd.singularValues()[i] != 0.0) { Sig(i, i) = 1.0 / svd.singularValues()[i]; }
-  }
-
-  // Pseudoinverse of the mixing matrix
+  svd.setThreshold(10 * std::numeric_limits<float>::epsilon());
   Eigen::Matrix<float, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS> mixer_matrix_pinv =
-    svd.matrixV() * Sig * svd.matrixU().transpose();
+    svd.solve(Eigen::Matrix<float, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS>::Identity());
 
   mixer_t inverted_mixer;
   // Fill in the mixing matrix from the inverted matrix above


### PR DESCRIPTION
The mixer inversion code checks singular values are not equal to zero before computing the pseudoinverse, to avoid division by zero in the rank-deficient mixing matrices. The equality check is not stable since it doesn't handle numerical noise, resulting in wrong values for the canned mixers.

This issue doesn't show up in sim (e.g. on my laptop), but it does show up when working on the hardware, and manifests itself as *very* wrong mixer values that can be seen when calling the `print_mixing_matrix` service. For example (after setting PRIMARY_MIXER=2):

```
[INFO] [1781552451.227462746] [rosflight_io]: Primary mixer:
 -1.8275e+08    0.0436897  -1.8275e+08   5.0242e+07  3.11302e+16  9.37673e+08            0            0            0            0
 1.16163e+16  3.71571e+07  1.16163e+16 -3.19359e+15  1.41542e+08 -1.39045e+25            0            0            0            0
 6.17406e+07    -0.802511  6.17406e+07 -1.69739e+07 -3.77277e+06 -7.39021e+16            0            0            0            0
-1.36971e+08    -0.791684 -1.36971e+08  3.76564e+07  8.63451e+08  1.63951e+17            0            0            0            0
   -0.407405    -0.353557     -1.11452     0.562762  2.11798e+07  7.62027e+08            0            0            0            0
   -0.126549        -0.25    -0.126549    -0.146478  -1.2494e-09   4.5072e+08            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
[INFO] [1781552451.227712745] [rosflight_io]: Secondary mixer:
 -1.8275e+08    0.0436897  -1.8275e+08   5.0242e+07  3.11302e+16  9.37673e+08            0            0            0            0
 1.16163e+16  3.71571e+07  1.16163e+16 -3.19359e+15  1.41542e+08 -1.39045e+25            0            0            0            0
 6.17406e+07    -0.802511  6.17406e+07 -1.69739e+07 -3.77277e+06 -7.39021e+16            0            0            0            0
-1.36971e+08    -0.791684 -1.36971e+08  3.76564e+07  8.63451e+08  1.63951e+17            0            0            0            0
   -0.407405    -0.353557     -1.11452     0.562762  2.11798e+07  7.62027e+08            0            0            0            0
   -0.126549        -0.25    -0.126549    -0.146478  -1.2494e-09   4.5072e+08            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
           0            0            0            0            0            0            0            0            0            0
```

This PR switches to the JacobiSVD's solve function, which internally sets singular values less than the threshold equal to zero ([see here](https://libeigen.gitlab.io/eigen/docs-nightly/classEigen_1_1SVDBase.html#a0ef8fe7049bebc721437034d8d236888)). We could achieve this by also doing the thresholding ourselves, but I think this is a cleaner approach.

This has been tested on a Pixracer Pro and fixes the issue.