### PR TITLE
Update for Ubuntu 26.04 and ROS 2 Lyrical

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # cmake --build build/test-release
 # ./build/test-release/test/unit_tests
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 project(rosflight_firmware C CXX ASM)
 

--- a/boards/varmint_h7/common/CMakeLists.txt
+++ b/boards/varmint_h7/common/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 ### project settings ###
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 
 if(NOT DEFINED TARGET_NAME)
     set(TARGET_NAME "varmint_h7")

--- a/boards/varmint_h7/pixracer_pro/CMakeLists.txt
+++ b/boards/varmint_h7/pixracer_pro/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 
 project(PixRacer_Pro)
 

--- a/boards/varmint_h7/varmint_10X/CMakeLists.txt
+++ b/boards/varmint_h7/varmint_10X/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 
 project(Varmint_10X)
 

--- a/boards/varmint_h7/varmint_11X/CMakeLists.txt
+++ b/boards/varmint_h7/varmint_11X/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 
 project(Varmint_11X)
 

--- a/include/command_manager.h
+++ b/include/command_manager.h
@@ -36,7 +36,6 @@
 
 #include "rc.h"
 
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/include/controller.h
+++ b/include/controller.h
@@ -39,7 +39,6 @@
 
 #include <turbomath/turbomath.h>
 
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/include/estimator.h
+++ b/include/estimator.h
@@ -37,7 +37,6 @@
 #include <turbomath/turbomath.h>
 
 #include <cmath>
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/include/interface/board.h
+++ b/include/interface/board.h
@@ -35,8 +35,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "board.h"
-
 namespace rosflight_firmware
 {
 

--- a/include/interface/board.h
+++ b/include/interface/board.h
@@ -32,7 +32,6 @@
 #ifndef ROSFLIGHT_FIRMWARE_BOARD_H
 #define ROSFLIGHT_FIRMWARE_BOARD_H
 
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -39,7 +39,6 @@
 #include <eigen/Eigen/Dense>
 #include <eigen/Eigen/SVD>
 
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/include/rc.h
+++ b/include/rc.h
@@ -36,7 +36,6 @@
 
 #include "param_listener.h"
 
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/include/sensors.h
+++ b/include/sensors.h
@@ -37,7 +37,6 @@
 
 #include "turbomath/turbomath.h"
 
-#include <cstdbool>
 #include <cstdint>
 #include <cstring>
 

--- a/src/command_manager.cpp
+++ b/src/command_manager.cpp
@@ -33,7 +33,6 @@
 
 #include "rosflight.h"
 
-#include <cstdbool>
 #include <cstdlib>
 
 namespace rosflight_firmware

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -36,7 +36,6 @@
 #include "mixer.h"
 #include "rosflight.h"
 
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -39,7 +39,6 @@
 #include "turbomath/turbomath.h"
 
 #include <cmath>
-#include <cstdbool>
 #include <cstdint>
 
 namespace rosflight_firmware

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_tests)
 
 add_definitions(-DGIT_VERSION_HASH=0x${GIT_VERSION_HASH})


### PR DESCRIPTION
The motivation for this pull request is to remove build warnings and errors when compiling on Ubuntu 26.04 for ROS 2 Lyrical.

Summary of Changes:

- Removed `cstdbool` header includes from C++ files. `cstdbool` was deprecated in C++ 17 (the build standard for Lyrical packages) and completely removed in C++ 20. C++ inherently includes the `bool` type and `true` and `false` keywords, so it is not necessary to include this header.
- Recursive include of `board.h` was removed from within `board.h`.
- CMake minimum policy version was bumped to the version currently set by `ros2 pkg create` with ROS 2 Lyrical (version 3.20).
- Included a CMake policy range for future proofing. Ubuntu 26.04 ships with CMake 4.2, but using the latest policies causes issues with GCC. Rather than trying to deal with debugging GCC and creating a pull request, I opted instead to back down the upper end of the policy range to 3.28 (which is what ships with Ubuntu 24.04). The version can be bumped to match the current version of CMake after the policy issues with GCC have been flushed out.
- Updated list of excluded directories in format script. Removed `Core`, `Drivers`, and `AL94_USB_Composite` since they no longer exist and added `boards` since this was Varmint-aided and it seems unsure how it should be formatted for now.
- ~~Ran `./scripts/fix-code-style.sh` to format code.~~ (removed after talking to Jacob so formatting can be done after other PRs are merged)

Note:

All tests passed when running the following test script:

``` bash
./scripts/run_tests.sh
```